### PR TITLE
Update colors to new Phrase palette

### DIFF
--- a/SkillChart/README.md
+++ b/SkillChart/README.md
@@ -1,3 +1,7 @@
+# Phrase Design Competencies Widget
+
+This widget visualizes the Phrase design competency levels across eight levels.
+
 Below are the steps to get your widget running. You can also find instructions at:
 
 https://www.figma.com/widget-docs/setup-guide/

--- a/SkillChart/code.js
+++ b/SkillChart/code.js
@@ -415,43 +415,64 @@
     Text,
     SVG
   } = widget;
-  var strategyCategory = {
-    name: "Strategy",
-    color: "#9747FF",
-    skills: ["Product", "Research", "Vision"],
-    skillDescriptions: ["What we're building and why", "Qualitative and quantitative evidence", "Future pathways and how things fit together"]
-  };
-  var craftCategory = {
-    name: "Craft",
-    color: "#0D99FF",
-    skills: ["Visual", "Interaction", "Systems"],
-    skillDescriptions: ["How things look", "How things behave", "Underlying models, IAs, etc."]
-  };
-  var writingCraftCategory = {
-    name: "Writing",
-    color: "#0D99FF",
-    skills: ["Content", "Copywriting", "Systems\u200B", "Design"],
-    skillDescriptions: ["Figuring out what to write", "Finding the perfect words", "Building consistency and cohesion", "Developing your UX design chops"]
-  };
-  var collabCategory = {
-    name: "Collaboration",
-    color: "#14AE5C",
-    skills: ["Communication", "Process", "Mindset"],
-    skillDescriptions: ["Written, verbal, and interpersonal skills", "Resiliency and growth orientation", "Sharing work and incorporating feedback"]
-  };
-  var impactCategory = {
-    name: "Impact",
-    color: "#FFCD29",
-    skills: ["Effectiveness", "Leadership", "Citizenship"],
-    skillDescriptions: ["Output, follow-through, and business impact", "Mentorship, ability to influence and drive change", "Improving our culture, hiring, and company practices"]
-  };
-  var categories = [strategyCategory, craftCategory, writingCraftCategory, collabCategory, impactCategory];
+var coreCategory = {
+  name: "Core",
+  color: "#005A9C",
+  skills: [
+    "Research",
+    "Craft and delivery",
+    "Strategy",
+    "Leadership",
+    "Impact",
+    "Design Systems"
+  ],
+  skillDescriptions: [
+    "User and market understanding",
+    "Executing with quality",
+    "Vision and planning",
+    "Guiding others",
+    "Delivering results",
+    "Reusable patterns and components"
+  ]
+};
+var productCategory = {
+  name: "Product Designer",
+  color: "#00853E",
+  skills: ["Domain Ownership", "User-Centered Problem Solving"],
+  skillDescriptions: [
+    "Deep knowledge of the product area",
+    "Identifying and solving user problems"
+  ]
+};
+var uiCategory = {
+  name: "Design System Designer",
+  color: "#7F3FBF",
+  skills: ["Interaction Design & Prototyping", "Visual Design & Aesthetics"],
+  skillDescriptions: [
+    "Interactive patterns and prototyping",
+    "Creating visually compelling experiences"
+  ]
+};
+var contentCategory = {
+  name: "Content Designer",
+  color: "#F27405",
+  skills: ["Content Strategy & Messaging", "Content Quality & Operations"],
+  skillDescriptions: [
+    "Shaping product messaging",
+    "Ensuring scalable, high-quality content"
+  ]
+};
+var categories = [coreCategory, productCategory, uiCategory, contentCategory];
   function Widget() {
     const voteMap = useSyncedMap("skill-level");
     const [userLevel, setUserLevel] = useSyncedState("level", 1);
     const [showLevels, setShowLevels] = useSyncedState("isShown", false);
-    const [role, setRole] = useSyncedState("role", "Design");
-    const roleOptions = [{ option: "Design", label: "Design" }, { option: "Writing", label: "Writing" }];
+    const [role, setRole] = useSyncedState("role", "Product Designer");
+    const roleOptions = [
+      { option: "Product Designer", label: "Product Designer" },
+      { option: "Content Designer", label: "Content Designer" },
+      { option: "Design System Designer", label: "Design System Designer" }
+    ];
     usePropertyMenu([
       {
         itemType: "dropdown",
@@ -484,7 +505,7 @@
       effect: [
         {
           type: "drop-shadow",
-          color: "#9747FF0A",
+          color: "#7F3FBF0A",
           offset: {
             x: 0,
             y: 3
@@ -494,7 +515,7 @@
         },
         {
           type: "drop-shadow",
-          color: "#0D99FF0A",
+          color: "#0074C40A",
           offset: {
             x: 0,
             y: 2
@@ -504,7 +525,7 @@
         },
         {
           type: "drop-shadow",
-          color: "#14AE5C0A",
+          color: "#0095750A",
           offset: {
             x: 0,
             y: 1
@@ -514,7 +535,7 @@
         },
         {
           type: "drop-shadow",
-          color: "#FFD54B0D",
+          color: "#FFAA000D",
           offset: {
             x: 0,
             y: 0

--- a/SkillChart/code.tsx
+++ b/SkillChart/code.tsx
@@ -21,7 +21,7 @@ type Category = {
 
 const coreCategory = {
   name: "Core",
-  color: "#007AA3",
+  color: "#005A9C",
   skills: [
     "Research",
     "Craft and delivery",
@@ -41,8 +41,8 @@ const coreCategory = {
 };
 
 const productCategory = {
-  name: "Product Design",
-  color: "#0E8A16",
+  name: "Product Designer",
+  color: "#00853E",
   skills: ["Domain Ownership", "User-Centered Problem Solving"],
   skillDescriptions: [
     "Deep knowledge of the product area",
@@ -51,8 +51,8 @@ const productCategory = {
 };
 
 const uiCategory = {
-  name: "UI",
-  color: "#9554CC",
+  name: "Design System Designer",
+  color: "#7F3FBF",
   skills: ["Interaction Design & Prototyping", "Visual Design & Aesthetics"],
   skillDescriptions: [
     "Interactive patterns and prototyping",
@@ -61,8 +61,8 @@ const uiCategory = {
 };
 
 const contentCategory = {
-  name: "Content Design",
-  color: "#D56300",
+  name: "Content Designer",
+  color: "#F27405",
   skills: ["Content Strategy & Messaging", "Content Quality & Operations"],
   skillDescriptions: [
     "Shaping product messaging",
@@ -78,11 +78,11 @@ function Widget() {
   const voteMap = useSyncedMap<number>("skill-level")
   const [userLevel, setUserLevel] = useSyncedState<number>('level', 1)
   const [showLevels, setShowLevels] = useSyncedState<boolean>("isShown", false)
-  const [role, setRole] = useSyncedState<string>("role", "Product Design")
+  const [role, setRole] = useSyncedState<string>("role", "Product Designer")
   const roleOptions = [
-    { option: "Product Design", label: "Product Design" },
-    { option: "UI", label: "UI" },
-    { option: "Content Design", label: "Content Design" }
+    { option: "Product Designer", label: "Product Designer" },
+    { option: "Content Designer", label: "Content Designer" },
+    { option: "Design System Designer", label: "Design System Designer" }
   ]
 
   usePropertyMenu(
@@ -121,7 +121,7 @@ function Widget() {
       effect={[
         {
           type: "drop-shadow",
-          color: "#9747FF0A",
+          color: "#7F3FBF0A",
           offset: {
             x: 0,
             y: 3,
@@ -132,7 +132,7 @@ function Widget() {
         },
         {
           type: "drop-shadow",
-          color: "#0D99FF0A",
+          color: "#0074C40A",
           offset: {
             x: 0,
             y: 2,
@@ -143,7 +143,7 @@ function Widget() {
         },
         {
           type: "drop-shadow",
-          color: "#14AE5C0A",
+          color: "#0095750A",
           offset: {
             x: 0,
             y: 1,
@@ -154,7 +154,7 @@ function Widget() {
         },
         {
           type: "drop-shadow",
-          color: "#FFD54B0D",
+          color: "#FFAA000D",
           offset: {
             x: 0,
             y: 0,
@@ -343,6 +343,11 @@ function Skill(
       width={250}
       height={716}
     >
+      <Rectangle
+        name={`Skill-Block-Bg-${name}`}
+        key={`Skill-Block-Bg-${skill_key}`}
+        opacity={0.2}
+        y={{ type: "bottom", offset: 1 }}
         fill={color}
         cornerRadius={6}
         width={250}

--- a/SkillChart/manifest.json
+++ b/SkillChart/manifest.json
@@ -1,5 +1,6 @@
 {
-  "name": "Skills Chart",
+  "name": "Phrase Design Competencies",
+  "description": "Widget to visualize Phrase design competency levels",
   "id": "1207836110040407856",
   "api": "1.0.0",
   "main": "code.js",

--- a/SkillChart/package.json
+++ b/SkillChart/package.json
@@ -1,7 +1,7 @@
 {
   "name": "Skills-Chart",
   "version": "1.0.0",
-  "description": "Your Figma widget",
+  "description": "Phrase design competencies widget",
   "main": "code.js",
   "scripts": {
     "build": "esbuild code.tsx --bundle --outfile=code.js"


### PR DESCRIPTION
## Summary
- switch category colors to new accessible Phrase brand colors
- update widget drop-shadow colors
- clarify that the widget visualizes Phrase design competencies

## Testing
- `npm run build` *(fails: esbuild not found)*

------
https://chatgpt.com/codex/tasks/task_b_684497d5cdec8330ba5d058378df8cb2